### PR TITLE
[init] trigger late_start on property change

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -353,7 +353,12 @@ on boot
     class_start core
     class_start main
 
+# Never gets called, since Mer does its own 'mount_all'
 on nonencrypted
+    class_start late_start
+
+# Mer needs to set this property when fs units are mounted
+on property:droid.late_start=trigger_late_start
     class_start late_start
 
 on charger


### PR DESCRIPTION
Merge counterpart: https://github.com/mer-hybris/droid-system-packager/pull/1

Android's late_start is triggered by mount_all, which also determines whether
the /data partition is encrypted.

Mer rootfs now has to spawn a service after mount points are ready, and before
peripheral services (such as sensors, wlan, bt, ...) are started. That service
has to issue `setprop droid.late_start trigger_late_start`
