### PR TITLE
mako wlan fwreload

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -353,7 +353,12 @@ on boot
     class_start core
     class_start main
 
+# Never gets called, since Mer does its own 'mount_all'
 on nonencrypted
+    class_start late_start
+
+# Mer needs to set this property when fs units are mounted
+on property:droid.late_start=trigger_late_start
     class_start late_start
 
 on charger

--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -439,12 +439,12 @@ service servicemanager /system/bin/servicemanager
 #    socket vold stream 0660 root mount
 #    ioprio be 2
 
-#Not used in Mer
-#service netd /system/bin/netd
-#    class main
-#    socket netd stream 0660 root system
-#    socket dnsproxyd stream 0660 root inet
-#    socket mdns stream 0660 root system
+# needed by `ndc softap fwreload wlan0 AP` command to reload mako firmware
+service netd /system/bin/netd
+    class main
+    socket netd stream 0660 root system
+    socket dnsproxyd stream 0660 root inet
+    socket mdns stream 0660 root system
 
 service debuggerd /system/bin/debuggerd
     class main


### PR DESCRIPTION
mako needs this service in order to be able to reload wlan firmware.

WLAN driver on mako is built-in module, and needs external trigger
to re-read firmware once it's in place by conn_init service.

On Android, WLAN firmware reloader logic is in WifiStateTracker.java
