### PR TITLE
[init] disable auditd, incompatible with new kernel flags

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -424,8 +424,10 @@ service console /system/bin/sh
     group log
     seclabel u:r:shell:s0
 
+# Disabled in Mer - together with CONFIG_AUDIT=n in mer-kernel-check
 service auditd /system/bin/auditd -k
     class main
+    disabled
 
 on property:ro.debuggable=1
     start console


### PR DESCRIPTION
...introduced by mer-kernel-check v0.0.3 (in https://github.com/mer-hybris/android_kernel_lge_hammerhead/pull/7 )
