### PR TITLE
[init] Add /usr/libexec/droid-hybris/lib-dev-alog/ to the LD_LIBRARY_PATH

### DIFF
--- a/rootdir/init.environ.rc.in
+++ b/rootdir/init.environ.rc.in
@@ -1,7 +1,8 @@
 # set up the global environment
 on init
     export PATH /sbin:/vendor/bin:/system/sbin:/system/bin:/system/xbin
-    export LD_LIBRARY_PATH /vendor/lib:/system/lib
+    # This is not 64-bit safe -stskeeps
+    export LD_LIBRARY_PATH /usr/libexec/droid-hybris/lib-dev-alog:/vendor/lib:/system/lib
     export ANDROID_BOOTLOGO 1
     export ANDROID_ROOT /system
     export ANDROID_ASSETS /system/app


### PR DESCRIPTION
So all init'ed binaries support `/dev/alog` used in Mer.

This is correctly set in `hybris-10.1` and `hybris-12.1` but not in `hybris-11.0`.

I've made a new commit based on 15fb87946511a620f21aaf0a5f9c872f4649841d.
Is that OK, or should we merge that commit into this branch?
