### PR TITLE
Disable setting hostname and domainname in init.rc.

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -416,8 +416,9 @@ on post-fs-data
 on boot
     # basic network init
     ifup lo
-    hostname localhost
-    domainname localdomain
+# Conflicts with Mer
+    #hostname localhost
+    #domainname localdomain
 
     # set RLIMIT_NICE to allow priorities from 19 to -20
     setrlimit 13 40 40


### PR DESCRIPTION
The lines cause the hostname to always be localhost but after commenting out the lines hostname is controlled by Mer
