### PR TITLE
(hybris) actdead: fix charging animation

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -417,7 +417,7 @@ on property:droid.late_start=trigger_late_start
     class_start late_start
 
 on charger
-    class_start charger
+    trigger late-init
 
 on property:vold.decrypt=trigger_reset_main
     class_reset main


### PR DESCRIPTION
Do not start the android charger class (which would fight on screen domination with actdead charging animation), just trigger late-init (which will trigger early-boot and boot)