### PR TITLE
[init] Update LD_LIBRARY_PATH to include 64bit paths

### DIFF
--- a/rootdir/init.environ.rc.in
+++ b/rootdir/init.environ.rc.in
@@ -2,8 +2,7 @@
 on init
 
     export PATH /sbin:/vendor/bin:/system/sbin:/system/bin:/system/xbin
-    # This is not 64-bit safe -stskeeps
-    export LD_LIBRARY_PATH /usr/libexec/droid-hybris/lib-dev-alog:/vendor/lib:/system/lib
+    export LD_LIBRARY_PATH /usr/libexec/droid-hybris/lib64-dev-alog:/vendor/lib64:/system/lib64:/usr/libexec/droid-hybris/lib-dev-alog:/vendor/lib:/system/lib
     export ANDROID_BOOTLOGO 1
     export ANDROID_ROOT /system
     export ANDROID_ASSETS /system/app


### PR DESCRIPTION
The path isn't set in stone since some devices have their vendor partition under /system/vendor rather than at the root. I guess a symlink could fix the issue