### PR TITLE
Gracefully shutdown android init services using new 'hybris.shutdown' property instead of killing them.

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -604,3 +604,9 @@ on ready
 service droid_init_done /bin/sh /usr/bin/droid/droid-init-done.sh
     class mer
     oneshot
+
+# Gracefully shutdown android init services using new 'hybris.shutdown' property instead of killing them.
+on property:hybris.shutdown=*
+    class_stop late_start
+    class_stop main
+    class_stop core


### PR DESCRIPTION
Needed by https://github.com/mer-hybris/droid-hal-configs/pull/95