### PR TITLE
(hybris) don't define 32-bit LD_LIBRARY_PATH for 64-bit devices

### DIFF
--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -10,9 +10,22 @@ LOCAL_MODULE := init.rc
 LOCAL_SRC_FILES := $(LOCAL_MODULE)
 LOCAL_MODULE_CLASS := ETC
 LOCAL_MODULE_PATH := $(TARGET_ROOT_OUT)
+LOCAL_REQUIRED_MODULES := init.extraenv.armeabi-v7a.rc
 
 include $(BUILD_PREBUILT)
 endif
+
+#######################################
+# init.extraenv.armeabi-v7a.rc
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := init.extraenv.armeabi-v7a.rc
+LOCAL_SRC_FILES := $(LOCAL_MODULE)
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_PATH := $(TARGET_ROOT_OUT)
+
+include $(BUILD_PREBUILT)
+
 #######################################
 # init.environ.rc
 

--- a/rootdir/init.environ.rc.in
+++ b/rootdir/init.environ.rc.in
@@ -2,7 +2,6 @@
 on init
 
     export PATH /sbin:/vendor/bin:/system/sbin:/system/bin:/system/xbin
-    export LD_LIBRARY_PATH /usr/libexec/droid-hybris/lib64-dev-alog:/vendor/lib64:/system/lib64:/usr/libexec/droid-hybris/lib-dev-alog:/vendor/lib:/system/lib
     export ANDROID_BOOTLOGO 1
     export ANDROID_ROOT /system
     export ANDROID_ASSETS /system/app

--- a/rootdir/init.extraenv.armeabi-v7a.rc
+++ b/rootdir/init.extraenv.armeabi-v7a.rc
@@ -1,0 +1,2 @@
+on init
+    export LD_LIBRARY_PATH /usr/libexec/droid-hybris/lib-dev-alog:/vendor/lib:/system/lib

--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -4,6 +4,11 @@
 # This is a common source of Android security bugs.
 #
 
+# this file is only necessary if your device is 32 bit and it is
+# using the android kernel logger if your device is 64 bit defining
+# LD_LIBRARY_PATH will break some binaries, since you cannot have both
+# 32 bit libraries and 64 bit libraries in your LD_LIBRARY_PATH.
+import /init.extraenv.${ro.product.cpu.abi}.rc
 import /init.environ.rc
 # Mer handles usb stuff
 #import /init.usb.rc


### PR DESCRIPTION
Most 64 bit devices don't need the lib64-dev-alog/lib-dev-alog hack since they don't use the kernel android logger driver anymore. But defining a LD_LIBRARY_PATH that contains both 32 bit and 64 bit libraries will break on mixed 32-64-bit devices. Therefore only use LD_LIBRARY_PATH with lib-dev-alog if the device is 32 bit only.