### PR TITLE
(hybris) Disable init_user0 which is not needed on Mer. JB#43903

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -518,7 +518,8 @@ on post-fs-data
     mkdir /data/cache/backup_stage 0700 system system
     mkdir /data/cache/backup 0700 system system
 
-    init_user0
+    # Requires vold which is is not needed in Mer
+    #init_user0
 
     # Set SELinux security contexts on upgrade or policy update.
     restorecon --recursive --skip-ce /data


### PR DESCRIPTION
This needs vold which is not needed in Mer. Removing so vold can be disabled.